### PR TITLE
add companies api endpoint support

### DIFF
--- a/blockscore/api/companies.py
+++ b/blockscore/api/companies.py
@@ -1,0 +1,35 @@
+# returns company api instance
+
+COMPANIES_PATH = '/companies'
+
+class Companies():
+
+	def __init__(self, client):
+		self.client = client
+
+	#
+	# '/companies' POST
+	#
+	def create(self, options = {}):
+		return self.client.post(COMPANIES_PATH, options)
+
+	#
+	# '/companies/:id' GET
+	#
+	def retrieve(self, id, options = {}):
+		body = options['query'] if 'query' in options else {}
+		return self.client.get('%s/%s' % (COMPANIES_PATH, str(id)), body)
+
+	#
+	# '/companies' GET
+	#
+	def all(self, count = None, offset = None, options = {}):
+		body = options['body'] if 'body' in options else {}
+
+		if count:
+			body['count'] = count
+		if offset:
+			body['offset'] = offset
+
+		return self.client.get(COMPANIES_PATH, body)
+

--- a/blockscore/client.py
+++ b/blockscore/client.py
@@ -3,6 +3,7 @@ from .http_client import HttpClient
 # Assign all the api classes
 from .api.verification import Verification
 from .api.question_set import QuestionSet
+from .api.companies import Companies
 
 class Client():
 
@@ -10,3 +11,5 @@ class Client():
 		self.http_client = HttpClient(auth, options)
 		self.verification = Verification(self.http_client)
 		self.question_set = QuestionSet(self.http_client)
+		self.companies = Companies(self.http_client)
+

--- a/test/companies.py
+++ b/test/companies.py
@@ -1,0 +1,66 @@
+if __name__ == '__main__' and __package__ is None:
+    from os import sys, path
+    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+import blockscore
+import unittest
+import os, sys
+
+class TestBlockscoreCompanies(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            self.client = blockscore.Client({'api_key': os.environ['BLOCKSCORE_API']})
+        except KeyError:
+            sys.stderr.write("To run tests, you must have a BLOCKSCORE_API environment variable with a test api key\n")
+            sys.exit(2)
+
+        self.test_company = {
+            "entity_name": "BlockScore",
+            "tax_id": "123410000",
+            "incorp_date": "1980-08-25",
+            "incorp_state": "DE",
+            "incorp_country_code": "US",
+            "incorp_type": "corporation",
+            "dbas": "BitRemite",
+            "registration_number": "123123123",
+            "email": "test@example.com",
+            "url": "https://blockscore.com",
+            "phone_number": "6505555555",
+            "ip_address": "67.160.8.182",
+            "address": {
+                "street1": "1 Infinite Loop",
+                "street2": None,
+                "city": "Cupertino",
+                "state": "CA",
+                "postal_code": "95014",
+                "country_code": "US",
+            }
+        }
+
+    def test_list_companies(self):
+        response = self.client.companies.all()
+        self.assertEqual(200, response.code)
+
+        response = self.client.companies.all(count=2)
+        self.assertEqual(200, response.code)
+
+        response = self.client.companies.all(count=2, offset=2)
+        self.assertEqual(200, response.code)
+
+    def test_retrieve_company(self):
+        response = self.client.companies.create(self.test_company)
+        body = response.body
+
+        response = self.client.companies.retrieve(body['id'])
+        body = response.body
+
+        self.assertEqual(200, response.code)
+        self.assertEqual(self.test_company['entity_name'], body['entity_name'])
+
+    def test_create_company(self):
+        response = self.client.companies.create(self.test_company)
+        self.assertEqual(201, response.code)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This adds the companies endpoint to the python library - based off of the existing ruby implementation. I realize this library still uses api endpoint 3.0, so I'll be sending separate pull request with the v4 compatible changes. 

Additionally, I've noticed that there's a mix of tabs/spaces across files. Which do you prefer? I'll fix it up.