### PR TITLE
verify certificates

### DIFF
--- a/blockscore/http_client/__init__.py
+++ b/blockscore/http_client/__init__.py
@@ -82,7 +82,7 @@ class HttpClient():
     del kwargs['base']
     del kwargs['user_agent']
 
-    kwargs['verify'] = False
+    kwargs['verify'] = True
 
     if method != 'get':
       kwargs = self.set_body(kwargs)


### PR DESCRIPTION
@alainmeier was getting a bunch of warnings regarding certificate verification, was there a reason for setting verify=False initially? This seems like a pretty quick win.